### PR TITLE
yaml: update Renesas Yocto revision to fixed v7.15.0

### DIFF
--- a/prod-devel-rcar-gen5-vdk.yaml
+++ b/prod-devel-rcar-gen5-vdk.yaml
@@ -39,7 +39,7 @@ common_data:
   domd_domu_sources: &DOMD_DOMU_SOURCES
     - type: git
       url: https://github.com/renesas-rcar/meta-renesas.git
-      rev: fe8e5b5e58d893166f698ba300cd25c49582b163 # scarthgap
+      rev: 10011a5098bdd8925c5f562aa76170b897c3ca6f # scarthgap
 
   # Common configuration options for all yocto-based domains
   conf: &COMMON_CONF


### PR DESCRIPTION
Change basic Yocto version to Renesas fixed v7.15.0 release to be in sync with the latest Renesas SDK 4.25.0 release.